### PR TITLE
Bi-directional monkeypatch

### DIFF
--- a/AudioContextMonkeyPatch.js
+++ b/AudioContextMonkeyPatch.js
@@ -45,93 +45,84 @@ and string types for AudioPannerNode.panningModel, AudioPannerNode.distanceModel
 BiquadFilterNode.type and OscillatorNode.type.
 
 */
-(function (global, exports, perf) {
-  'use strict';
 
-  function fixSetTarget(param) {
-    if (!param)	// if NYI, just return
-      return;
-    if (!param.setTargetAtTime)
-      param.setTargetAtTime = param.setTargetValueAtTime; 
-  }
-
-  if (window.hasOwnProperty('webkitAudioContext') && 
-      !window.hasOwnProperty('AudioContext')) {
-    window.AudioContext = webkitAudioContext;
-
-    AudioContext.prototype.internal_createGain = AudioContext.prototype.createGain;
-    AudioContext.prototype.createGain = function() { 
-      var node = this.internal_createGain();
-      fixSetTarget(node.gain);
-      return node;
-    };
-
-    AudioContext.prototype.internal_createDelay = AudioContext.prototype.createDelay;
-    AudioContext.prototype.createDelay = function() { 
-      var node = this.internal_createDelay();
-      fixSetTarget(node.delayTime);
-      return node;
-    };
-
-    AudioContext.prototype.internal_createBufferSource = AudioContext.prototype.createBufferSource;
-    AudioContext.prototype.createBufferSource = function() { 
-      var node = this.internal_createBufferSource();
-      if (!node.start) {
-        node.start = function ( when, offset, duration ) {
-          if ( offset || duration )
-            this.noteGrainOn( when, offset, duration );
-          else
-            this.noteOn( when );
-        }
-      }
-      if (!node.stop)
-        node.stop = node.noteoff;
-      fixSetTarget(node.playbackRate);
-      return node;
-    };
-
-    AudioContext.prototype.internal_createDynamicsCompressor = AudioContext.prototype.createDynamicsCompressor;
-    AudioContext.prototype.createDynamicsCompressor = function() { 
-      var node = this.internal_createDynamicsCompressor();
-      fixSetTarget(node.threshold);
-      fixSetTarget(node.knee);
-      fixSetTarget(node.ratio);
-      fixSetTarget(node.reduction);
-      fixSetTarget(node.attack);
-      fixSetTarget(node.release);
-      return node;
-    };
-
-    AudioContext.prototype.internal_createBiquadFilter = AudioContext.prototype.createBiquadFilter;
-    AudioContext.prototype.createBiquadFilter = function() { 
-      var node = this.internal_createBiquadFilter();
-      fixSetTarget(node.frequency);
-      fixSetTarget(node.detune);
-      fixSetTarget(node.Q);
-      fixSetTarget(node.gain);
-      return node;
-    };
-
-    if (AudioContext.prototype.hasOwnProperty( 'createOscillator' )) {
-      AudioContext.prototype.internal_createOscillator = AudioContext.prototype.createOscillator;
-      AudioContext.prototype.createOscillator = function() { 
-        var node = this.internal_createOscillator();
-        if (!node.start)
-          node.start = node.noteOn; 
-        if (!node.stop)
-          node.stop = node.noteOff;
-        fixSetTarget(node.frequency);
-        fixSetTarget(node.detune);
-        return node;
-      };
+/*
+srikumarks (a.k.a. Kumar): In the code below, all the name aliasing is done at
+the time the audio context is instantiated. This approach also makes no
+reference to current parameter sets of other nodes so that it is robust to the
+api evolving to some extent -- it only depends on the gain node having a "gain"
+parameter.
+*/
+;(function () {
+    var GLOBAL = this;
+    if (GLOBAL.AudioContext) {
+        // Don't do anything. This client already supports
+        // an unprefixed AudioContext.
+        return;
     }
 
-    if (!AudioContext.prototype.hasOwnProperty('createGain'))
-      AudioContext.prototype.createGain = AudioContext.prototype.createGainNode;
-    if (!AudioContext.prototype.hasOwnProperty('createDelay'))
-      AudioContext.prototype.createDelay = AudioContext.prototype.createDelayNode;
-    if (!AudioContext.prototype.hasOwnProperty('createScriptProcessor'))
-      AudioContext.prototype.createScriptProcessor = AudioContext.prototype.createJavaScriptNode;
-  }
-}(window));
+    GLOBAL.AudioContext = (function (AC) {
+        'use strict';
+
+        if (!AC) {
+            throw new Error('No AudioContext available in this browser.');
+        }
+
+        return function AudioContext() {
+            var ac, AudioParam, AudioParamOld, BufferSource, Oscillator;
+
+            if (arguments.length === 0) {
+                // Realtime audio context.
+                ac = new AC;
+            } else if (arguments.length === 3) {
+                // Offline audio context.
+                ac = new AC(arguments[0], arguments[1], arguments[2]);
+            } else {
+                throw new Error('Invalid instantiation of AudioContext');
+            }
+
+            ac.createGain = (ac.createGain || ac.createGainNode);
+            ac.createDelay = (ac.createDelay || ac.createDelayNode);
+            ac.createScriptProcessor = (ac.createScriptProcessor || ac.createJavaScriptNode);
+
+            // Find out the AudioParam prototype object.
+            // Some older implementations keep an additional empty
+            // interface for the gain parameter.
+            AudioParam = Object.getPrototypeOf(ac.createGain().gain);
+            AudioParamOld = Object.getPrototypeOf(AudioParam);
+            if (AudioParamOld.setValueAtTime) {
+                // Checking for the presence of setValueAtTime to find whether
+                // it is the right prototype class is, I expect, more robust than
+                // checking whether the class name is this or that. - Kumar
+                AudioParam = AudioParamOld;
+            }
+
+            AudioParam.setTargetAtTime = (AudioParam.setTargetAtTime || AudioParam.setTargetValueAtTime);
+
+            // For BufferSource node, we need to also account for noteGrainOn.
+            BufferSource = Object.getPrototypeOf(ac.createBufferSource());
+
+            if (!BufferSource.start) {
+                BufferSource.start = function start(when, offset, duration) {
+                    // Support only one or three argument form.
+                    switch (arguments.length) {
+                        case 1: return this.noteOn(when);
+                        case 3: return this.noteGrainOn(when, offset, duration);
+                        default: throw new Error('Invalid number of arguments to BufferSource.start');
+                    }
+                };
+            }
+
+            if (!BufferSource.stop) {
+               BufferSource.stop = BufferSource.noteOff;
+            }
+
+            Oscillator = Object.getPrototypeOf(ac.createOscillator());
+            Oscillator.start = (Oscillator.start || Oscillator.noteOn);
+            Oscillator.stop = (Oscillator.stop || Oscillator.noteOff);
+
+            return ac;
+        };
+    }(GLOBAL.AudioContext || GLOBAL.webkitAudioContext));
+}());
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,15 @@ and that use the new naming and proper bits of the Web Audio API (e.g.
 using BufferSourceNode.start() instead of BufferSourceNode.noteOn()), but may
 have to run on systems that only support the deprecated bits.
 
-This library should be harmless to include if the browser supports 
-unprefixed "AudioContext", and/or if it supports the new names.  
+Kumar: This version of the patch is bi-directional - i.e. it makes new
+names available in older implementations and vice versa, so that old
+code can keep running while new code works as well. It supports
+the following 4 use cases -
+
+1. Old code + New unprefixed implementation
+2. Old code + Old prefixed implementation with old names
+3. New code + New unprefixed implementation
+4. New code + Old prefixed implementation with old names
 
 The patches this library handles:
 ---------------------------------
@@ -33,3 +40,6 @@ BiquadFilterNode.type and OscillatorNode.type.
 
 You can copy the AudioContextMonkeyPatch.js into your project if you
 like, or include it as http://cwilso.github.com/AudioContext-MonkeyPatch/AudioContextMonkeyPatch.js.
+
+Kumar: Note that the aliasing is both ways - i.e. if only noteOn/noteOff is
+available, start() and stop() will be added to work using those.


### PR DESCRIPTION
This monkey patch works bidirectionally, so that sites can take the time to port over old code to new API names while having their site continue to work on engines that only support new names.
