### PR TITLE
Adding optional maxDelayTime parameter into internal_createDelay

### DIFF
--- a/AudioContextMonkeyPatch.js
+++ b/AudioContextMonkeyPatch.js
@@ -74,8 +74,8 @@ BiquadFilterNode.type and OscillatorNode.type.
     };
 
     AudioContext.prototype.internal_createDelay = AudioContext.prototype.createDelay;
-    AudioContext.prototype.createDelay = function() { 
-      var node = this.internal_createDelay();
+    AudioContext.prototype.createDelay = function(maxDelayTime) { 
+      var node = this.internal_createDelay(maxDelayTime);
       fixSetTarget(node.delayTime);
       return node;
     };


### PR DESCRIPTION
Without this, all delay times default to a max of 1 second.
