### PR TITLE
Added aliases for createWaveTable and setWaveTable (for Safari)

### DIFF
--- a/AudioContextMonkeyPatch.js
+++ b/AudioContextMonkeyPatch.js
@@ -98,8 +98,6 @@ BiquadFilterNode.type and OscillatorNode.type.
       }
       if (!node.stop)
         node.stop = node.noteOff;
-      if (!node.setPeriodicWave)
-        node.setPeriodicWave = node.setWaveTable;
       fixSetTarget(node.playbackRate);
       return node;
     };
@@ -134,6 +132,8 @@ BiquadFilterNode.type and OscillatorNode.type.
           node.start = node.noteOn; 
         if (!node.stop)
           node.stop = node.noteOff;
+        if (!node.setPeriodicWave)
+          node.setPeriodicWave = node.setWaveTable;
         fixSetTarget(node.frequency);
         fixSetTarget(node.detune);
         return node;

--- a/AudioContextMonkeyPatch.js
+++ b/AudioContextMonkeyPatch.js
@@ -35,8 +35,10 @@ AudioBufferSourceNode.stop() is aliased to noteOff()
 AudioContext.createGain() is aliased to createGainNode()
 AudioContext.createDelay() is aliased to createDelayNode()
 AudioContext.createScriptProcessor() is aliased to createJavaScriptNode()
+AudioContext.createPeriodicWave() is aliased to createWaveTable()
 OscillatorNode.start() is aliased to noteOn()
 OscillatorNode.stop() is aliased to noteOff()
+OscillatorNode.setPeriodicWave() is aliased to setWaveTable()
 AudioParam.setTargetAtTime() is aliased to setTargetValueAtTime()
 
 This library does NOT patch the enumerated type changes, as it is 
@@ -65,6 +67,9 @@ BiquadFilterNode.type and OscillatorNode.type.
       AudioContext.prototype.createDelay = AudioContext.prototype.createDelayNode;
     if (!AudioContext.prototype.hasOwnProperty('createScriptProcessor'))
       AudioContext.prototype.createScriptProcessor = AudioContext.prototype.createJavaScriptNode;
+    if (!AudioContext.prototype.hasOwnProperty('createPeriodicWave'))
+      AudioContext.prototype.createPeriodicWave = AudioContext.prototype.createWaveTable;
+
 
     AudioContext.prototype.internal_createGain = AudioContext.prototype.createGain;
     AudioContext.prototype.createGain = function() { 
@@ -93,6 +98,8 @@ BiquadFilterNode.type and OscillatorNode.type.
       }
       if (!node.stop)
         node.stop = node.noteOff;
+      if (!node.setPeriodicWave)
+        node.setPeriodicWave = node.setWaveTable;
       fixSetTarget(node.playbackRate);
       return node;
     };

--- a/README.md
+++ b/README.md
@@ -18,13 +18,15 @@ noteGrainOn(), depending on parameters.
 
 The following aliases only take effect if the new names are not already in place:
 
-AudioBufferSourceNode.stop() is aliased to noteOff()
-AudioContext.createGain() is aliased to createGainNode()
-AudioContext.createDelay() is aliased to createDelayNode()
-AudioContext.createScriptProcessor() is aliased to createJavaScriptNode()
-OscillatorNode.start() is aliased to noteOn()
-OscillatorNode.stop() is aliased to noteOff()
-AudioParam.setTargetAtTime() is aliased to setTargetValueAtTime()
+- AudioBufferSourceNode.stop() is aliased to noteOff()
+- AudioContext.createGain() is aliased to createGainNode()
+- AudioContext.createDelay() is aliased to createDelayNode()
+- AudioContext.createScriptProcessor() is aliased to createJavaScriptNode()
+- AudioContext.createPeriodicWave() is aliased to createWaveTable()
+- OscillatorNode.start() is aliased to noteOn()
+- OscillatorNode.stop() is aliased to noteOff()
+- AudioParam.setTargetAtTime() is aliased to setTargetValueAtTime()
+- OscillatorNode.setPeriodicWave() is aliased to setWaveTable()
 
 This library does NOT patch the enumerated type changes, as it is 
 recommended in the specification that implementations support both integer


### PR DESCRIPTION
Safari still uses createWaveTable and setWaveTable instead of createPeriodicWave and setPeriodicWave
