### PR TITLE
Added basic alias for OfflineAudioContext

### DIFF
--- a/AudioContextMonkeyPatch.js
+++ b/AudioContextMonkeyPatch.js
@@ -140,5 +140,11 @@ BiquadFilterNode.type and OscillatorNode.type.
       };
     }
   }
+
+  if (window.hasOwnProperty('webkitOfflineAudioContext') && 
+      !window.hasOwnProperty('OfflineAudioContext')) {
+    window.OfflineAudioContext = webkitOfflineAudioContext;
+  }
+  
 }(window));
 


### PR DESCRIPTION
It might not be enough, but at least permits to use standard Web Audio API in Safari (7) here:
https://jipodine.github.io/reverbGen/

I do not know if we should replicate the AudioContext prototypes. Moreover,I do not know anything about the convolver node.
