### PR TITLE
Fix .start for iOS9. #15

### DIFF
--- a/AudioContextMonkeyPatch.js
+++ b/AudioContextMonkeyPatch.js
@@ -13,16 +13,16 @@
    limitations under the License.
 */
 
-/* 
+/*
 
 This monkeypatch library is intended to be included in projects that are
-written to the proper AudioContext spec (instead of webkitAudioContext), 
-and that use the new naming and proper bits of the Web Audio API (e.g. 
+written to the proper AudioContext spec (instead of webkitAudioContext),
+and that use the new naming and proper bits of the Web Audio API (e.g.
 using BufferSourceNode.start() instead of BufferSourceNode.noteOn()), but may
 have to run on systems that only support the deprecated bits.
 
-This library should be harmless to include if the browser supports 
-unprefixed "AudioContext", and/or if it supports the new names.  
+This library should be harmless to include if the browser supports
+unprefixed "AudioContext", and/or if it supports the new names.
 
 The patches this library handles:
 if window.AudioContext is unsupported, it will be aliased to webkitAudioContext().
@@ -41,9 +41,9 @@ OscillatorNode.stop() is aliased to noteOff()
 OscillatorNode.setPeriodicWave() is aliased to setWaveTable()
 AudioParam.setTargetAtTime() is aliased to setTargetValueAtTime()
 
-This library does NOT patch the enumerated type changes, as it is 
+This library does NOT patch the enumerated type changes, as it is
 recommended in the specification that implementations support both integer
-and string types for AudioPannerNode.panningModel, AudioPannerNode.distanceModel 
+and string types for AudioPannerNode.panningModel, AudioPannerNode.distanceModel
 BiquadFilterNode.type and OscillatorNode.type.
 
 */
@@ -54,10 +54,10 @@ BiquadFilterNode.type and OscillatorNode.type.
     if (!param)	// if NYI, just return
       return;
     if (!param.setTargetAtTime)
-      param.setTargetAtTime = param.setTargetValueAtTime; 
+      param.setTargetAtTime = param.setTargetValueAtTime;
   }
 
-  if (window.hasOwnProperty('webkitAudioContext') && 
+  if (window.hasOwnProperty('webkitAudioContext') &&
       !window.hasOwnProperty('AudioContext')) {
     window.AudioContext = webkitAudioContext;
 
@@ -72,21 +72,21 @@ BiquadFilterNode.type and OscillatorNode.type.
 
 
     AudioContext.prototype.internal_createGain = AudioContext.prototype.createGain;
-    AudioContext.prototype.createGain = function() { 
+    AudioContext.prototype.createGain = function() {
       var node = this.internal_createGain();
       fixSetTarget(node.gain);
       return node;
     };
 
     AudioContext.prototype.internal_createDelay = AudioContext.prototype.createDelay;
-    AudioContext.prototype.createDelay = function(maxDelayTime) { 
+    AudioContext.prototype.createDelay = function(maxDelayTime) {
       var node = maxDelayTime ? this.internal_createDelay(maxDelayTime) : this.internal_createDelay();
       fixSetTarget(node.delayTime);
       return node;
     };
 
     AudioContext.prototype.internal_createBufferSource = AudioContext.prototype.createBufferSource;
-    AudioContext.prototype.createBufferSource = function() { 
+    AudioContext.prototype.createBufferSource = function() {
       var node = this.internal_createBufferSource();
       if (!node.start) {
         node.start = function ( when, offset, duration ) {
@@ -101,7 +101,7 @@ BiquadFilterNode.type and OscillatorNode.type.
           if( typeof duration !== 'undefined' )
             node.internal_start( when || 0, offset, duration );
           else
-            node.internal_start( when || 0, offset );     
+            node.internal_start( when || 0, offset || 0 );
         };
       }
       if (!node.stop) {
@@ -119,7 +119,7 @@ BiquadFilterNode.type and OscillatorNode.type.
     };
 
     AudioContext.prototype.internal_createDynamicsCompressor = AudioContext.prototype.createDynamicsCompressor;
-    AudioContext.prototype.createDynamicsCompressor = function() { 
+    AudioContext.prototype.createDynamicsCompressor = function() {
       var node = this.internal_createDynamicsCompressor();
       fixSetTarget(node.threshold);
       fixSetTarget(node.knee);
@@ -131,7 +131,7 @@ BiquadFilterNode.type and OscillatorNode.type.
     };
 
     AudioContext.prototype.internal_createBiquadFilter = AudioContext.prototype.createBiquadFilter;
-    AudioContext.prototype.createBiquadFilter = function() { 
+    AudioContext.prototype.createBiquadFilter = function() {
       var node = this.internal_createBiquadFilter();
       fixSetTarget(node.frequency);
       fixSetTarget(node.detune);
@@ -142,7 +142,7 @@ BiquadFilterNode.type and OscillatorNode.type.
 
     if (AudioContext.prototype.hasOwnProperty( 'createOscillator' )) {
       AudioContext.prototype.internal_createOscillator = AudioContext.prototype.createOscillator;
-      AudioContext.prototype.createOscillator = function() { 
+      AudioContext.prototype.createOscillator = function() {
         var node = this.internal_createOscillator();
         if (!node.start) {
           node.start = function ( when ) {
@@ -173,10 +173,10 @@ BiquadFilterNode.type and OscillatorNode.type.
     }
   }
 
-  if (window.hasOwnProperty('webkitOfflineAudioContext') && 
+  if (window.hasOwnProperty('webkitOfflineAudioContext') &&
       !window.hasOwnProperty('OfflineAudioContext')) {
     window.OfflineAudioContext = webkitOfflineAudioContext;
   }
-  
+
 }(window));
 


### PR DESCRIPTION
Turns out the problem wasn't with `when` but rather that `offset` was being passed into start even when `undefined`. For example, in chrome, calling `.start(0, undefined)` will throw a `Uncaught TypeError: Failed to execute 'start' on 'AudioBufferSourceNode': The provided double value is non-finite.`, whereas in desktop Safari playback will be successful. In Mobile Safari on iOS 9:  `InvalidStateError: DOM Exception 11: An attempt was made to use an object that is not, or is no longer, usable.`

I'd like to take a second pass through the logic of the argument handling... nearly all of the parameters are optional according to the spec, but because the checks in the monkey patch are truthy/falsy I'm not sure if all cases are accurately handled.

Regardless, thanks for the monkey patch, this thing has saved me tons of time :)
